### PR TITLE
log4j2.xml root logger is now at INFO

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="warn">
+    <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
     <Logger name="com.solace" level="info" additivity="false">


### PR DESCRIPTION
This is to fix https://github.com/SolaceProducts/solace-hybridedge/issues/6.